### PR TITLE
chore: add additional rules for _fieldExample for demo config

### DIFF
--- a/aplib.net-demo/.editorconfig
+++ b/aplib.net-demo/.editorconfig
@@ -235,7 +235,7 @@ dotnet_naming_style.begins_with_i.capitalization = pascal_case
 dotnet_naming_symbols.private_fields.applicable_kinds           = field
 dotnet_naming_symbols.private_fields.applicable_accessibilities = internal, protected_internal, private 
 
-dotnet_naming_style.prefix_underscore.capitalization = camel_case
+dotnet_naming_style.prefix_underscore.capitalization  = camel_case
 dotnet_naming_style.prefix_underscore.required_prefix = _
 
 dotnet_naming_rule.private_fields_with_underscore.symbols  = private_fields

--- a/aplib.net-demo/.editorconfig
+++ b/aplib.net-demo/.editorconfig
@@ -229,3 +229,15 @@ dotnet_naming_style.begins_with_i.required_prefix = I
 dotnet_naming_style.begins_with_i.required_suffix = 
 dotnet_naming_style.begins_with_i.word_separator = 
 dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+[*.{cs,vb}]
+# Use underscores for private fields
+dotnet_naming_symbols.private_fields.applicable_kinds           = field
+dotnet_naming_symbols.private_fields.applicable_accessibilities = internal, protected_internal, private 
+
+dotnet_naming_style.prefix_underscore.capitalization = camel_case
+dotnet_naming_style.prefix_underscore.required_prefix = _
+
+dotnet_naming_rule.private_fields_with_underscore.symbols  = private_fields
+dotnet_naming_rule.private_fields_with_underscore.style    = prefix_underscore
+dotnet_naming_rule.private_fields_with_underscore.severity = warning


### PR DESCRIPTION
Added the same code block to the unity .editorconfig to make _fieldExample not a warning but the default for internal, private, and protected_internal settings.