### PR TITLE
fix: dotnet format staged files only

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,6 @@
+# Auto detect text files and perform LF normalization
+*.cs       text diff=csharp eol=lf
+*.cshtml   text diff=html   eol=lf
+*.csx      text diff=csharp eol=lf
+*.sln      text             eol=lf
+*.csproj   text             eol=lf

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,7 +1,27 @@
 #!/bin/sh
+
+# Boilerplate husky
 . "$(dirname "$0")/_/husky.sh"
 
-dotnet format -v diag aplib.net-demo/aplib.net-demo.sln
+# Find all c# related staged files, before doing anything
+FILES_TO_BE_FORMATTED=$(git diff --staged --name-only | grep -E '\.(cs|csproj|sln)$' || echo '')
 
-# Add files changed by husky to git
-git add .
+if [ -z $FILES_TO_BE_FORMATTED ]; then
+	echo "No .NET files to format, skipping dotnet format..."
+	exit 0
+fi
+
+echo "Files to be formatted:"
+for file in $FILES_TO_BE_FORMATTED; do
+    echo " - $file"
+done
+echo "" # new-line for clarity
+
+# Format c# related staged files only
+echo $FILES_TO_BE_FORMATTED | xargs dotnet format -v diag aplib.net-demo/aplib.net-demo.sln --include 
+
+# Add all formatted files again, to add changed files
+echo $FILES_TO_BE_FORMATTED | xargs git add
+
+echo -e "\nDone formatting files!\nCheck the log to find out if files have changed.\n"
+

--- a/aplib.net-demo/.editorconfig
+++ b/aplib.net-demo/.editorconfig
@@ -12,7 +12,7 @@ indent_style = space
 tab_width = 4
 
 # New line preferences
-end_of_line = crlf
+end_of_line = lf
 insert_final_newline = true
 
 #### .NET Coding Conventions ####


### PR DESCRIPTION
## Description

Previously, husky would `dotnet format` the whole solution, and add all files afterwards.

Now, `dotnet format` only targets staged files, and only adds said files after formatting.
Notable differences are that only 'committed' files are changed, and all other files are kept as-is and not added to git after formatting.

Furthermore, a `.gitattributes.` file has been introduced and the `.editorconfig` is updated, where both changes now enforce `lf` instead of `crlf`, since every upstream file has `lf` line endings.

## Checklist
- [x] Set the proper pull request name
- [x] Merged main into your branch