### PR TITLE
fix: editor and room connections

### DIFF
--- a/aplib.net-demo/Assets/Editor/GridPlacerEditor.cs
+++ b/aplib.net-demo/Assets/Editor/GridPlacerEditor.cs
@@ -15,6 +15,7 @@ namespace Editors
             SerializedObject gridPlacerSettings = serializedObject;
 
             SerializedProperty roomObjects = gridPlacerSettings.FindProperty("_roomObjects");
+            SerializedProperty doorPrefab = gridPlacerSettings.FindProperty("_doorPrefab");
             SerializedProperty useSeed = gridPlacerSettings.FindProperty("_useSeed");
             SerializedProperty seed = gridPlacerSettings.FindProperty("_seed");
             SerializedProperty tileSizeX = gridPlacerSettings.FindProperty("_tileSizeX");
@@ -24,6 +25,7 @@ namespace Editors
             SerializedProperty amountOfRooms = gridPlacerSettings.FindProperty("_amountOfRooms");
 
             roomObjects.objectReferenceValue = EditorGUILayout.ObjectField("Room objects", roomObjects.objectReferenceValue, typeof(RoomObjects), false);
+            doorPrefab.objectReferenceValue = EditorGUILayout.ObjectField("Door prefab", doorPrefab.objectReferenceValue, typeof(GameObject), false);
             useSeed.boolValue = EditorGUILayout.Toggle("Use seed", useSeed.boolValue);
             if (useSeed.boolValue) seed.intValue = EditorGUILayout.IntField("Seed", seed.intValue);
             tileSizeX.intValue = EditorGUILayout.IntField("Tile size X", tileSizeX.intValue);

--- a/aplib.net-demo/Assets/Scenes/WaveFunctionCollapse.unity
+++ b/aplib.net-demo/Assets/Scenes/WaveFunctionCollapse.unity
@@ -273,6 +273,8 @@ MonoBehaviour:
   _tileSizeX: 16
   _tileSizeZ: 16
   _roomObjects: {fileID: 11400000, guid: 9962865d7cc12a74abe02efdb8b7d072, type: 2}
+  _doorPrefab: {fileID: 3526522355453958696, guid: 22b08b26ebf57994bb9b9f1004aa58ca,
+    type: 3}
   _useSeed: 0
   _seed: 0
   _gridWidthX: 10

--- a/aplib.net-demo/Assets/Scripts/WFC/Grid.cs
+++ b/aplib.net-demo/Assets/Scripts/WFC/Grid.cs
@@ -148,9 +148,10 @@ namespace Assets.Scripts.Wfc
             List<Direction> directions = new() { North, East, South, West };
 
             if (cell.X == 0) directions.Remove(North);
-            if (cell.X == Width - 1) directions.Remove(South);
+            else if (cell.X == Width - 1) directions.Remove(South);
+
             if (cell.Z == 0) directions.Remove(West);
-            if (cell.Z == Height - 1) directions.Remove(East);
+            else if (cell.Z == Height - 1) directions.Remove(East);
 
             PlaceRoom(cell.X, cell.Z, new Room(directions));
 

--- a/aplib.net-demo/Assets/Scripts/WFC/Grid.cs
+++ b/aplib.net-demo/Assets/Scripts/WFC/Grid.cs
@@ -144,7 +144,15 @@ namespace Assets.Scripts.Wfc
 
             int index = _random.Next(notFinished.Count);
             Cell cell = notFinished[index];
-            PlaceRoom(cell.X, cell.Z, new Room(new() { North, East, South, West }));
+
+            List<Direction> directions = new() { North, East, South, West };
+
+            if (cell.X == 0) directions.Remove(North);
+            if (cell.X == Width - 1) directions.Remove(South);
+            if (cell.Z == 0) directions.Remove(West);
+            if (cell.Z == Height - 1) directions.Remove(East);
+
+            PlaceRoom(cell.X, cell.Z, new Room(directions));
 
             RemoveUnconnectedNeighbourCandidates(cell);
         }


### PR DESCRIPTION
## Description

This PR proposes to add the door prefab to the GridPlacer editor and to remove the room connections outside the grid.

## Testability

Run the WaveFunctionCollapse scene.

## Checklist
- [X] Set the proper pull request name
- [X] Merged main into your branch
- [X] Added a scene to the game for your changes