### PR TITLE
fix: fix door placement direction

### DIFF
--- a/aplib.net-demo/Assets/Scripts/Tiles/Direction.cs
+++ b/aplib.net-demo/Assets/Scripts/Tiles/Direction.cs
@@ -5,8 +5,8 @@ namespace Assets.Scripts.Tiles
     /// </summary>
     public enum Direction
     {
-        North = 0,
-        East = 1,
+        North = 0, // The positive z-direction.
+        East = 1, // The poritive x-direction.
         South = 2,
         West = 3
     }

--- a/aplib.net-demo/Assets/Scripts/WFC/Grid.cs
+++ b/aplib.net-demo/Assets/Scripts/WFC/Grid.cs
@@ -147,11 +147,11 @@ namespace Assets.Scripts.Wfc
 
             List<Direction> directions = new() { North, East, South, West };
 
-            if (cell.X == 0) directions.Remove(North);
-            else if (cell.X == Width - 1) directions.Remove(South);
+            if (cell.X == 0) directions.Remove(West);
+            else if (cell.X == Width - 1) directions.Remove(East);
 
-            if (cell.Z == 0) directions.Remove(West);
-            else if (cell.Z == Height - 1) directions.Remove(East);
+            if (cell.Z == 0) directions.Remove(South);
+            else if (cell.Z == Height - 1) directions.Remove(North);
 
             PlaceRoom(cell.X, cell.Z, new Room(directions));
 

--- a/aplib.net-demo/Assets/Scripts/WFC/GridPlacer.cs
+++ b/aplib.net-demo/Assets/Scripts/WFC/GridPlacer.cs
@@ -206,10 +206,10 @@ namespace Assets.Scripts.Wfc
                 // North is in the negative x direction
                 Vector3 relativeDoorPosition = direction switch
                 {
-                    North => new Vector3(-doorDistanceFromRoomCenter, 0, 0),
-                    East => new Vector3(0, 0, doorDistanceFromRoomCenter),
-                    South => new Vector3(doorDistanceFromRoomCenter, 0, 0),
-                    West => new Vector3(0, 0, -doorDistanceFromRoomCenter),
+                    North => new Vector3(0, 0, doorDistanceFromRoomCenter),
+                    East => new Vector3(doorDistanceFromRoomCenter, 0, 0),
+                    South => new Vector3(0, 0, -doorDistanceFromRoomCenter),
+                    West => new Vector3(-doorDistanceFromRoomCenter, 0, 0),
                     _ => throw new UnityException("Invalid direction when placing door")
                 };
                 Vector3 doorPosition = roomPosition + relativeDoorPosition;
@@ -218,7 +218,7 @@ namespace Assets.Scripts.Wfc
 
                 // The `RotateLeft` here is because the rotation of the grid and the rotation of the door model do not
                 // line up
-                Quaternion relativeDoorRotation = Quaternion.Euler(0, direction.RotateLeft().RotationDegrees(), 0);
+                Quaternion relativeDoorRotation = Quaternion.Euler(0, direction.RotationDegrees(), 0);
                 Quaternion doorRotation = roomRotation * relativeDoorRotation;
 
                 // # Spawn the door


### PR DESCRIPTION
## Description

In this PR the placement directions of the doors are placed so they follow the same direction as the connected components

## Testability

Open and run the scene WaveFunctionCollapse

## Checklist
- [X] Set the proper pull request name
- [X] Merged main into your branch
- [X] Added a scene to the game for your changes