### PR TITLE
fix: sonar cloud unshallow fetching build warning

### DIFF
--- a/.github/workflows/test-build-release.yaml
+++ b/.github/workflows/test-build-release.yaml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - uses: actions/cache@v4
         with:
           path: ./aplib.net-demo/Library

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -12,7 +12,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
         with:
-          fetch-depth: 1
+          fetch-depth: 0
       - name: Fetch Main Branch
         run: git fetch origin main:main
       - uses: actions/cache@v4


### PR DESCRIPTION
## Description

This PR enables the unshallow fetching. SonarCloud will now hopefully stop complaining about the pipeline :)


## Checklist
- [x] Set the proper pull request name
- [x] Merged main into your branch
- [N/A] Added a scene to the game for your changes