### PR TITLE
feat: add color to separated components and game over trigger when end item is used

### DIFF
--- a/aplib.net-demo/Assets/Scripts/Items/EndItem.cs
+++ b/aplib.net-demo/Assets/Scripts/Items/EndItem.cs
@@ -1,8 +1,15 @@
-using UnityEngine;
-
 namespace Assets.Scripts.Items
 {
     public class EndItem : Item
     {
+        /// <summary>
+        /// Uses the end item and triggers game over.
+        /// </summary>
+        public override void UseItem()
+        {
+            base.UseItem();
+
+            GameManager.Instance.TriggerGameOver();
+        }
     }
 }

--- a/aplib.net-demo/Assets/Scripts/LevelGeneration/LevelSpawner.cs
+++ b/aplib.net-demo/Assets/Scripts/LevelGeneration/LevelSpawner.cs
@@ -176,9 +176,7 @@ namespace LevelGeneration
             {
                 Color componentColor = Random.ColorHSV(0f, 1f, _minSaturation, _maxSaturation, _minValue, _maxValue);
                 foreach (Cell cell in connectedComponent)
-                {
                     cell.Tile.GameObject.GetComponent<Renderer>().material.color = componentColor;
-                }
             }
         }
 

--- a/aplib.net-demo/Assets/Scripts/LevelGeneration/LevelSpawner.cs
+++ b/aplib.net-demo/Assets/Scripts/LevelGeneration/LevelSpawner.cs
@@ -166,6 +166,10 @@ namespace LevelGeneration
             ProcessNeighbouringRooms(startComponent, neighbouringRooms, connectedComponents, doors);
         }
 
+        /// <summary>
+        /// Colors the connected components.
+        /// </summary>
+        /// <param name="connectedComponents">The connected components to color.</param>
         private void ColorConnectedComponent(IEnumerable<ConnectedComponent> connectedComponents)
         {
             foreach (ConnectedComponent connectedComponent in connectedComponents)

--- a/aplib.net-demo/Assets/Scripts/LevelGeneration/LevelSpawner.cs
+++ b/aplib.net-demo/Assets/Scripts/LevelGeneration/LevelSpawner.cs
@@ -9,6 +9,7 @@ using UnityEngine.AI;
 using WFC;
 using ConnectedComponent = System.Collections.Generic.ISet<WFC.Cell>;
 using Grid = WFC.Grid;
+using Random = UnityEngine.Random;
 
 namespace LevelGeneration
 {
@@ -20,6 +21,14 @@ namespace LevelGeneration
     [RequireComponent(typeof(SpawningExtensions))]
     public class LevelSpawner : MonoBehaviour
     {
+        private readonly float _maxSaturation = 1f;
+
+        private readonly float _maxValue = 1f;
+
+        private readonly float _minSaturation = 0.5f;
+
+        private readonly float _minValue = 0.3f;
+
         /// <summary>
         /// The height of the offset of where we place the teleporter, with respect to the cell's floor.
         /// </summary>
@@ -149,10 +158,24 @@ namespace LevelGeneration
 
             MergeConnectedComponentsJoinedByTeleporterPair(teleporterList, connectedComponents);
 
+            ColorConnectedComponent(connectedComponents.Select(t => t.connectedComponent));
+
             (ConnectedComponent startComponent, ConnectedComponent neighbouringRooms) =
                 FindAndRemoveCellConnectedComponent(startCell, connectedComponents);
 
             ProcessNeighbouringRooms(startComponent, neighbouringRooms, connectedComponents, doors);
+        }
+
+        private void ColorConnectedComponent(IEnumerable<ConnectedComponent> connectedComponents)
+        {
+            foreach (ConnectedComponent connectedComponent in connectedComponents)
+            {
+                Color componentColor = Random.ColorHSV(0f, 1f, _minSaturation, _maxSaturation, _minValue, _maxValue);
+                foreach (Cell cell in connectedComponent)
+                {
+                    cell.Tile.GameObject.GetComponent<Renderer>().material.color = componentColor;
+                }
+            }
         }
 
         /// <summary>

--- a/aplib.net-demo/Assets/Scripts/SharedRandom.cs
+++ b/aplib.net-demo/Assets/Scripts/SharedRandom.cs
@@ -36,7 +36,7 @@ namespace ThreadSafeRandom
             }
 
             _local = new Random(_seed);
-            UnityRandom.seed = _seed;
+            UnityRandom.InitState(_seed);
         }
 
         public static int Seed()
@@ -60,7 +60,7 @@ namespace ThreadSafeRandom
                         _local = new Random(seed);
                     }
 
-                UnityRandom.seed = _seed;
+                UnityRandom.InitState(_seed);
             }
         }
 

--- a/aplib.net-demo/Assets/Scripts/SharedRandom.cs
+++ b/aplib.net-demo/Assets/Scripts/SharedRandom.cs
@@ -1,5 +1,6 @@
 #nullable enable
 using System;
+using UnityRandom = UnityEngine.Random;
 
 namespace ThreadSafeRandom
 {
@@ -35,6 +36,7 @@ namespace ThreadSafeRandom
             }
 
             _local = new Random(_seed);
+            UnityRandom.seed = _seed;
         }
 
         public static int Seed()
@@ -57,6 +59,8 @@ namespace ThreadSafeRandom
                     {
                         _local = new Random(seed);
                     }
+
+                UnityRandom.seed = _seed;
             }
         }
 


### PR DESCRIPTION
## Description

Added color to separated components and a game over trigger when end item is used.

## Testability

Open the main scene and see the random deterministic colors. When the end item is used the game over screen should appear.

## Checklist
- [X] Set the proper pull request name
- [X] Merged main into your branch
- [X] Added a scene to the game for your changes